### PR TITLE
issue#29 fixed - adding complete path

### DIFF
--- a/src/view/frontend/web/js/limesharp_stockists.js
+++ b/src/view/frontend/web/js/limesharp_stockists.js
@@ -47,7 +47,7 @@ define([
 	            
 	            // get the stores from admin stockists/ajax/stores
 	            function getStores() {
-	                var url = window.location.protocol+"//"+window.location.host + "/" + config.moduleUrl + '/ajax/stores';
+	                var url = window.location.protocol+"//"+window.location.pathname + '/ajax/stores';
 	                $.ajax({
 	                    dataType: 'json',
 	                    url: url


### PR DESCRIPTION
#29 is fixed.
* It was due to wrong path when there is an additional element within url (e.g. http://localhost/magentodir/stockist/).
* It is expected that the ajax request to get Stores would be initiated from stockists page