### PR TITLE
Stockists URL dependency removed from the ajax call.

### DIFF
--- a/src/view/frontend/web/js/limesharp_stockists.js
+++ b/src/view/frontend/web/js/limesharp_stockists.js
@@ -47,7 +47,7 @@ define([
 	            
 	            // get the stores from admin stockists/ajax/stores
 	            function getStores() {
-	                var url = window.location.protocol+"//"+window.location.hostname+window.location.pathname;
+	                var url = window.location.protocol+"//"+window.location.hostname+"//"+"stockists";
                     	url = (url.substr(-1) != '/' ? url+'/':url)+'ajax/stores';
 
 	                $.ajax({


### PR DESCRIPTION
From the admin configuration, if you change the Stockists URL from default "stockists" to let's say "stores", the ajax call to fetch all stores breaks because it changes the route's name. 
The actual controller should be <base url>/stockists/ajax/stores
The broken link is <base url>/<stockists url>/ajax/stores.

This fix hardcodes the URL back to "stockists" because that is the frontend route name. 